### PR TITLE
Create Help

### DIFF
--- a/lib/freckle.ex
+++ b/lib/freckle.ex
@@ -4,15 +4,46 @@ defmodule Freckle do
   """
 
   @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> Freckle.hello
-      :world
-
+  Enrtry Point
   """
-  def hello do
-    :world
+  def main(args \\ []) do
+     args
+      |> digest_arguments
+      |> process
+  end
+
+  defp digest_arguments(args) do
+    options =
+      args
+      |> OptionParser.parse(
+        switches: [help: :boolean, version: :boolean],
+        aliases: [h: :help, v: :version])
+
+    case options do
+      { [ help: true ], _, _ }    -> :help
+      { [ version: true ], _, _ } -> :version
+      _                           -> :help
+    end
+  end
+
+  defp process(:help) do
+    """
+    USAGE
+    =====
+      freckle --project PROJECT --for HH:MM:SS
+      freckle [-h | --help]
+      freckle [-v | --version]
+
+    ARGS
+    ====
+
+        PROJECT    The project you want to log time for
+        HH:MM:SS   Hours, minutes, and seconds you want to log
+    """
+    |> IO.puts
+  end
+
+  defp process(:version) do
+    IO.puts("Version 0.0.0")
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,8 @@ defmodule Freckle.MixProject do
       version: "0.1.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      escript: escript()
     ]
   end
 
@@ -24,5 +25,9 @@ defmodule Freckle.MixProject do
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
     ]
+  end
+
+  defp escript do
+    [main_module: Freckle]
   end
 end


### PR DESCRIPTION
Every good command line tool has a robust "Help" section. This instructs
the user on how to use the tool, what to look out for, gotchas, and
could have some shameful marketing to go along with it.

I want to add a help section to the tool. This help is going to be
minimal for now because my purview for the application at this point is
quite limited. The text in this help would be revised moving forward

This is done by:
- Showing...
    - The syntax for running the application
    - Possible flags one could use to run the application and what these
      flags mean
    - Shameful marketing pointing people to this GitHub account

Resolves #2