### PR TITLE
Read Configuration

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -1,0 +1,2 @@
+PERSONAL_ACCESS_TOKEN=gotten_from_freckle
+DOMAIN=your_company_name

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,3 +28,15 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+
+configuration = case File.read(Path.expand("~/.bellboy")) do
+  { :ok, bellboy_instructions } ->
+    bellboy_instructions
+    |> String.split("\n")
+    |> Enum.reject(fn x -> x == "" end)
+    |> Enum.map(fn pair -> pair |> String.split("=") end)
+    |> Enum.map(fn [a, b] -> { a |> String.downcase |> String.to_atom, b } end)
+  { :error, :enoent } -> :ok
+end
+
+config :freckle, configuration

--- a/lib/freckle.ex
+++ b/lib/freckle.ex
@@ -7,9 +7,9 @@ defmodule Freckle do
   Enrtry Point
   """
   def main(args \\ []) do
-     args
-      |> digest_arguments
-      |> process
+    args
+    |> digest_arguments
+    |> process
   end
 
   defp digest_arguments(args) do


### PR DESCRIPTION
Seemingly, from the documentation, tools use a "Personal Access Token" which is
generated on Freckle. There is an OAuth method, but I don't have the mental
space to wrap my head aroung this.

I choose to put this in a hidden configuration file in the home directory. Then
I'd read this into memory when the tool is being started. This access token is
then used to do everything afterwards.

Sometime in the future, I would be moving this to the OAuth method.