### PR TITLE
Call me Bellboy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 freckle-*.tar
 
+# Ignore the executable (build via "mix escript.build).
+bellboy

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# Freckle
+# Bellboy
 
 **TODO: Add description**
 
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `freckle` to your list of dependencies in `mix.exs`:
+by adding `bellboy` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:freckle, "~> 0.1.0"}
+    {:bellboy, "~> 0.1.0"}
   ]
 end
 ```
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/freckle](https://hexdocs.pm/freckle).
+be found at [https://hexdocs.pm/bellboy](https://hexdocs.pm/bellboy).
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -39,4 +39,4 @@ configuration = case File.read(Path.expand("~/.bellboy")) do
   { :error, :enoent } -> :ok
 end
 
-config :freckle, configuration
+config :bellboy, configuration

--- a/lib/bellboy.ex
+++ b/lib/bellboy.ex
@@ -1,6 +1,6 @@
-defmodule Freckle do
+defmodule Bellboy do
   @moduledoc """
-  Documentation for Freckle.
+  Documentation for Bellboy.
   """
 
   @doc """
@@ -30,9 +30,9 @@ defmodule Freckle do
     """
     USAGE
     =====
-      freckle --project PROJECT --for HH:MM:SS
-      freckle [-h | --help]
-      freckle [-v | --version]
+      bellboy --project PROJECT --for HH:MM:SS
+      bellboy [-h | --help]
+      bellboy [-v | --version]
 
     ARGS
     ====

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,9 @@
-defmodule Freckle.MixProject do
+defmodule Bellboy.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :freckle,
+      app: :bellboy,
       version: "0.1.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
@@ -28,6 +28,6 @@ defmodule Freckle.MixProject do
   end
 
   defp escript do
-    [main_module: Freckle]
+    [main_module: Bellboy]
   end
 end

--- a/test/bellboy_test.exs
+++ b/test/bellboy_test.exs
@@ -1,0 +1,8 @@
+defmodule BellboyTest do
+  use ExUnit.Case
+  doctest Bellboy
+
+  # test "greets the world" do
+  #   assert Bellboy.hello() == :world
+  # end
+end

--- a/test/freckle_test.exs
+++ b/test/freckle_test.exs
@@ -1,8 +1,0 @@
-defmodule FreckleTest do
-  use ExUnit.Case
-  doctest Freckle
-
-  test "greets the world" do
-    assert Freckle.hello() == :world
-  end
-end


### PR DESCRIPTION
Freckle has some legalities around the naming. It would be unwise to continue
with this as a name for the tool. I would rather have the nanmes that stay
clear of the "Freckle" key word; albeit names like "Freckle Commandline Tool -
FCT" being as descriptive as possible. So I checked what freckles are
associated with, and "Bellboy" came up. ...since this is something which would
be logging my time for me anyways

I did this by:

- changing all `Freckle` to `Bellboy` in any case

Resolves #7