### PR TITLE
Create an Entry

### DIFF
--- a/lib/bellboy.ex
+++ b/lib/bellboy.ex
@@ -1,6 +1,8 @@
 defmodule Bellboy do
   @moduledoc """
   Documentation for Bellboy.
+
+  A CLI tool to put time on Freckle.
   """
 
   @doc """
@@ -24,32 +26,44 @@ defmodule Bellboy do
         aliases: [h: :help, v: :version])
 
     case options do
-      { [ help: true ], _, _ }    -> :help
-      { [], ["projects"], [] }    -> :list_projects
-      { [ version: true ], _, _ } -> :version
-      _                           -> :help
+      { [ help: true ], _, _ }                     -> :help
+      { [], [ "projects" ], [] }                   -> :list_projects
+      { [ for: project_id ], [ "log", time ], [] } -> { :log, time, project_id }
+      { [ version: true ], _, _ }                  -> :version
+      _                                            -> :help
     end
   end
 
   defp process(:help) do
     """
+
     USAGE
     =====
-      bellboy --project PROJECT --for HH:MM:SS
+      bellboy projects
+      bellboy log TIME --for PROJECT_ID
       bellboy [-h | --help]
       bellboy [-v | --version]
 
     ARGS
     ====
 
-        PROJECT    The project you want to log time for
-        HH:MM:SS   Hours, minutes, and seconds you want to log
+        PROJECT_ID    The project to log time for
+        TIME          Time in minutes
     """
     |> IO.puts
   end
 
   defp process(:list_projects) do
     Bellboy.Freckle_Client.list(:projects)
+  end
+
+  defp process({:log, time, project_id}) do
+    { minutes, _ } = Integer.parse(time)
+
+    Bellboy.Freckle_Client.create(:entries, %{
+      "project_id" => project_id,
+      "minutes" => minutes
+    })
   end
 
   defp process(:version) do

--- a/lib/bellboy/freckle_client.ex
+++ b/lib/bellboy/freckle_client.ex
@@ -1,4 +1,19 @@
 defmodule Bellboy.Freckle_Client do
+  def create(:entries, data \\ %{}) do
+    post_data = Map.merge(data, %{"date": Date.utc_today |> Date.to_string})
+
+    { :ok, response } = HTTPoison.post(
+      base_url() <> "/entries",
+      post_data |> Poison.encode!,
+      headers()
+    )
+
+    case response.status_code do
+      201 -> IO.puts("  🎩 Done")
+      400 -> IO.puts("  🚫 Something went wrong")
+    end
+  end
+
   def list(:projects) do
     render_title      = "Your Projects on Freckle"
     render_header     = [ "Project Name", "Project ID" ]


### PR DESCRIPTION
This is it, people. Finally, we are here. The reason we are doing this whole
thing in the first place. This issue is concerned with asking bellboy to put
some time on Freckle. One should be able to say `bellboy record <time> --for
<project_id>`; and this would create an entry on freckle.

This was done by

- extending the Freckle client
- creating new command map for logging time
- updating the documentation

Resolves #11