### PR TITLE
Fix personal token key name

### DIFF
--- a/lib/bellboy/freckle_client.ex
+++ b/lib/bellboy/freckle_client.ex
@@ -33,7 +33,7 @@ defmodule Bellboy.Freckle_Client do
 
   defp headers do
     [
-      "X-FreckleToken": Application.get_env(:bellboy, :freckle_token)
+      "X-FreckleToken": Application.get_env(:bellboy, :personal_access_token)
     ]
   end
 end


### PR DESCRIPTION
Hi @igbanam 	
Awesome work on this project 🏆 

When trying it out to list my projects after adding the config values, I was constantly getting this error:
```
** (Poison.ParseError) Unexpected end of input at position 1
    (poison) lib/poison/parser.ex:357: Poison.Parser.value/3
    (poison) lib/poison/parser.ex:64: Poison.Parser.parse!/2
    (poison) lib/poison.ex:86: Poison.decode!/2
    (bellboy) lib/bellboy/freckle_client.ex:24: Bellboy.Freckle_Client.list/1
    (elixir) lib/kernel/cli.ex:105: anonymous fn/3 in Kernel.CLI.exec_fun/2
```

I found that the app is trying to get the access token as `freckle_token` instead of `personal_access_token` which is the correct name according to `config.sample`

This fixes the above issue 😄 

