### PR TITLE
Make a Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,11 @@
 
 ## Installation
 
-### From Binary
-- Download the executable file
-- Run `chmod +x bellboy`
-- Move `bellboy` to somewhere in your path
+### Get your personal access token from Freckle
 
-### From the repository
-- Clone the repository
-- Run `mix escript.build`
-
-## How to use
-
-In order to use Bellboy, you need to know two things: the subdomain of your company and an access token from Freckle. To get this access token, follow these steps
+In order to use Bellboy, you need to know two things: the subdomain of your
+company and an access token from Freckle. To get this access token, follow
+these steps
 
 - Login to Freckle
 - On the left sidebar, click on Connected Apps
@@ -23,6 +16,23 @@ In order to use Bellboy, you need to know two things: the subdomain of your comp
 - Click the "Settings…" beside "Personal Access Token"
 - Follow the prompts to generate Personal Access Token
 
-With these information, edit the content of `config.sample` and store it in `~/.bellboy`
+With these information, edit the content of `config.sample` and store it in
+`~/.bellboy`
 
-Start with `./bellboy -h`
+### Buildiing Bellboy
+
+- Clone the repository
+- Run `mix escript.build`
+
+## How to use
+
+- Start with `./bellboy -h`
+
+---
+
+Notes:
+
+- Since EScript apps are compiled into an executable, all variables required
+  for its smooth running should be available at copmile time. This is the
+reason you would have to get your personal access token before compiling the
+app. This is an inconvenience, and I am still looking for a work around

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 ## Installation
 
 ### From Binary
-- Download the executable file 
+- Download the executable file
+- Run `chmod +x bellboy`
+- Move `bellboy` to somewhere in your path
 
 ### From the repository
 - Clone the repository

--- a/config/config.exs
+++ b/config/config.exs
@@ -36,7 +36,7 @@ configuration = case File.read(Path.expand("~/.bellboy")) do
     |> Enum.reject(fn x -> x == "" end)
     |> Enum.map(fn pair -> pair |> String.split("=") end)
     |> Enum.map(fn [a, b] -> { a |> String.downcase |> String.to_atom, b } end)
-  { :error, :enoent } -> :ok
+  { :error, :enoent } -> System.halt("Configure with ~/.bellboy")
 end
 
 config :bellboy, configuration

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,21 @@ mix deps.get
 mix deps.compile
 
 # get their personal access token
+echo "Do you have your Freckle personal access token copied?"
+echo "Check the README for steps on how to get this from Freckle."
+read -p "Paste your Personal Access Token: " personal_access_token
 
 # write their personal access token into ~/.bellboy
+echo PERSONAL_ACCESS_TOKEN=${personal_access_token} > ~/.bellboy
+
+# get their company domain
+echo Enter your company domain name.
+echo For Andela, use "andela.com"
+read -p "Domain: " company_domain
+
+# add company domain to ~/.bellboy
+echo DOMAIN=${company_domain} >> ~/.bellboy
 
 mix escript.build
+
+mv ./bellboy /usr/local/bin

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 if [[ ! -x `which elixir` ]]
+then
   brew install elixir
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,15 @@
+if [[ ! -x `which elixir` ]]
+  brew install elixir
+fi
+
+mix local.hex --force
+mix local.rebar --force
+
+mix deps.get
+mix deps.compile
+
+# get their personal access token
+
+# write their personal access token into ~/.bellboy
+
+mix escript.build

--- a/lib/bellboy/freckle_client.ex
+++ b/lib/bellboy/freckle_client.ex
@@ -1,6 +1,6 @@
 defmodule Bellboy.Freckle_Client do
   def create(:entries, data \\ %{}) do
-    post_data = Map.merge(data, %{"date": Date.utc_today |> Date.to_string})
+    post_data = Map.merge(data, %{date: Date.utc_today |> Date.to_string})
 
     { :ok, response } = HTTPoison.post(
       base_url() <> "/entries",

--- a/lib/bellboy/project.ex
+++ b/lib/bellboy/project.ex
@@ -1,48 +1,4 @@
 defmodule Bellboy.Project do
   @derive [Poison.Encoder]
   defstruct [:id, :name]
-
-
-    # {
-    #     "archive_url": "https://api.letsfreckle.com/v2/projects/442962/archive",
-    #     "billable": true,
-    #     "billable_minutes": 23805,
-    #     "billing_increment": 15,
-    #     "budgeted_minutes": null,
-    #     "color": "#d6c0fb",
-    #     "created_at": "2017-05-31T10:07:44Z",
-    #     "enabled": true,
-    #     "entries": 99,
-    #     "entries_url": "https://api.letsfreckle.com/v2/projects/442962/entries",
-    #     "group": null,
-    #     "id": 442962,
-    #     "invoiced_minutes": 0,
-    #     "merge_url": "https://api.letsfreckle.com/v2/projects/442962/merge",
-    #     "minutes": 23805,
-    #     "name": "Internal Products",
-    #     "participants": [
-    #         {
-    #             "email": "damilola.akapo@andela.com",
-    #             "first_name": "Damilola",
-    #             "id": 65204,
-    #             "last_name": "Akapo",
-    #             "profile_image_url": "",
-    #             "url": "https://api.letsfreckle.com/v2/users/65204"
-    #         },
-    #         {
-    #             "email": "owajigbanam.ogbuluijah@andela.com",
-    #             "first_name": "Owajigbanam",
-    #             "id": 63363,
-    #             "last_name": "Ogbuluijah",
-    #             "profile_image_url": "",
-    #             "url": "https://api.letsfreckle.com/v2/users/63363"
-    #         }
-    #     ],
-    #     "remaining_minutes": null,
-    #     "unarchive_url": "https://api.letsfreckle.com/v2/projects/442962/unarchive",
-    #     "unbillable_minutes": 0,
-    #     "uninvoiced_minutes": 23805,
-    #     "updated_at": "2018-05-28T07:41:43Z",
-    #     "url": "https://api.letsfreckle.com/v2/projects/442962"
-    # },
 end


### PR DESCRIPTION
To reduce the barrier between product and potential customers, we need
to create a release which is enticing enough to reduce the pain the
customers feel when they are using BellBoy. This release should be able
to understand when they have not configured BellBoy properly, and guide
them in doing so.

This change addresses the need by:

* updating the installation instructions in the README
* ensure that the application does not crash on misconfiguration
* guide users on how to get their personal access token from Freckle
* create a `~/.bellboy` file if one does not already exist

Closes #21